### PR TITLE
增加了一个复制按钮以解决复制的文本有bom头的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ ModuleNotFoundError: No module named 'PyQt5'
 
 ```
 
-这时候可以直接用`pip3 install PyQt5`
+这时候可以直接用
+`pip3 install PyQt5`
+`pip3 install pyperclip`
 等待安装完成
 
 后面使用就是在命令行敲入

--- a/README.md
+++ b/README.md
@@ -3,3 +3,34 @@
 
 用法：
 ![](https://github.com/debuggerx01/JSONFormat4Flutter/blob/master/Example/json.gif?raw=true)
+
+## 友情提示
+没有python运行环境的用户需要先安装python
+
+mac中可以使用如下命令安装
+```
+brew install python3
+brew install pip3
+```
+pip3是python3的包管理工具
+
+brew 可以参考下面的链接
+
+https://brew.sh/index_zh-cn
+
+运行库的时候会可能会提示
+```
+Traceback (most recent call last):
+  File "formater.py", line 8, in <module>
+    from mainwindow import *
+  File "/Users/cjl/IdeaProjects/flutter/sxw-flutter-app/JSONFormat4Flutter/mainwindow.py", line 9, in <module>
+    from PyQt5 import QtCore, QtGui, QtWidgets
+ModuleNotFoundError: No module named 'PyQt5'
+
+```
+
+这时候可以直接用`pip3 install PyQt5`
+等待安装完成
+
+后面使用就是在命令行敲入
+`python3 formater.py`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 用法：
 ![](https://github.com/debuggerx01/JSONFormat4Flutter/blob/master/Example/json.gif?raw=true)
 
-## 友情提示
+## MAC使用方法
 没有python运行环境的用户需要先安装python
 
 mac中可以使用如下命令安装

--- a/formater.py
+++ b/formater.py
@@ -6,7 +6,6 @@
 from functools import partial
 
 from mainwindow import *
-
 from tools import *
 
 # 定义显示的json格式化字符串的缩进量为4个空格
@@ -182,7 +181,12 @@ def generate_bean():
 
         bean.append([var_field, var_type, var_name])
 
-    res = check_and_generate_code(bean)
+    try:
+        res = check_and_generate_code(bean)
+    except IndexError as e:
+        print(e)
+        QMessageBox().information(msg_box_ui, "警告", "发生错误", QMessageBox.Ok)
+        return
     if res != '':
         ui.te_json.setText(res)
 
@@ -191,6 +195,15 @@ def init_event():
     # 绑定json解析按钮事件
     ui.btn_format.clicked.connect(json_format)
     ui.btn_generate.clicked.connect(generate_bean)
+    ui.btn_copy.clicked.connect(copy_left_text)
+
+
+def copy_left_text():
+    ## 第三方库 用于解决跨平台的复制粘贴和复制的文本带bom问题
+    import pyperclip
+    text = ui.te_json.toPlainText()
+    pyperclip.copy(text)
+    pass
 
 
 # 设置表格基础样式

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -2,16 +2,17 @@
 
 # Form implementation generated from reading ui file 'mainwindow.ui'
 #
-# Created by: PyQt5 UI code generator 5.6
+# Created by: PyQt5 UI code generator 5.10.1
 #
 # WARNING! All changes made in this file will be lost!
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
+
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
-        MainWindow.resize(927, 724)
+        MainWindow.resize(927, 716)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -49,6 +50,9 @@ class Ui_MainWindow(object):
         self.te_json = QtWidgets.QTextEdit(self.layoutWidget)
         self.te_json.setObjectName("te_json")
         self.verticalLayout_3.addWidget(self.te_json)
+        self.btn_copy = QtWidgets.QPushButton(self.layoutWidget)
+        self.btn_copy.setObjectName("btn_copy")
+        self.verticalLayout_3.addWidget(self.btn_copy)
         self.layoutWidget1 = QtWidgets.QWidget(self.splitter)
         self.layoutWidget1.setObjectName("layoutWidget1")
         self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.layoutWidget1)
@@ -74,6 +78,7 @@ class Ui_MainWindow(object):
         _translate = QtCore.QCoreApplication.translate
         MainWindow.setWindowTitle(_translate("MainWindow", "JSONFormat4Flutter"))
         self.btn_format.setText(_translate("MainWindow", "格式化"))
+        self.btn_copy.setText(_translate("MainWindow", "复制"))
         self.btn_generate.setText(_translate("MainWindow", "生成Bean"))
 
 
@@ -86,4 +91,3 @@ if __name__ == "__main__":
     ui.setupUi(widget)
     widget.show()
     sys.exit(app.exec_())
-

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>927</width>
-    <height>724</height>
+    <height>716</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -61,6 +61,13 @@
            </item>
            <item>
             <widget class="QTextEdit" name="te_json"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="btn_copy">
+             <property name="text">
+              <string>复制</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>


### PR DESCRIPTION
增加了一个复制按钮,用于复制代码,以解决qt5内的文本框直接复制会有bom头的问题  …
复制的第三库pyperclip

捕获了IndexError 以防止点击右部生成Bean时可能崩溃的bug

README中增加了使用说明